### PR TITLE
Bump CSS cache-bust version after mobile location fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         href="data:image/svg+xml,&lt;svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'&gt;&lt;text y='.9em' font-size='90'&gt;❤️&lt;/text&gt;&lt;/svg&gt;">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="css/style.css?v=40dbbe23807">
+    <link rel="stylesheet" href="css/style.css?v=10a70e73">
     <!-- Load fonts async so they don't block first paint -->
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lora:wght@400;500;600&family=Montserrat:wght@300;400;500;600&family=Poppins:wght@300;400;500;600&family=Playfair+Display:wght@400;500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lora:wght@400;500;600&family=Montserrat:wght@300;400;500;600&family=Poppins:wght@300;400;500;600&family=Playfair+Display:wght@400;500;600&display=swap"></noscript>
@@ -1169,7 +1169,7 @@
     </footer>
 </div>
 
-<script src="js/script.js?v=40dbbe23807"></script>
+<script src="js/script.js?v=10a70e73"></script>
 
 <!-- Reveal the "Share Your Photos" link only on/after the wedding day.
      Add ?showupload=1 to the URL to preview it before then. -->

--- a/upload/index.html
+++ b/upload/index.html
@@ -10,7 +10,7 @@
         href="data:image/svg+xml,&lt;svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'&gt;&lt;text y='.9em' font-size='90'&gt;❤️&lt;/text&gt;&lt;/svg&gt;">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="../css/style.css?v=40dbbe23807">
+    <link rel="stylesheet" href="../css/style.css?v=10a70e73">
     <link rel="preload" as="style"
         href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lora:wght@400;500;600&family=Montserrat:wght@300;400;500;600&family=Poppins:wght@300;400;500;600&family=Playfair+Display:wght@400;500;600&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
Updates the `?v=` cache-bust hash in `index.html` and `upload/index.html` to `10a70e73` so browsers load the new `style.css` with the mobile location fix instead of the cached version.

---
_Generated by [Claude Code](https://claude.ai/code/session_017XXDeaDAA9y1qxYkFWKHzU)_