### PR TITLE
Show registry section after wedding date

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -336,12 +336,12 @@ function applyDateRules() {
 }
 
 function applyPostWeddingState() {
-    ['#details', '#map', '#recs', '#accommodations', '#registry', '#rsvp'].forEach(function(id) {
+    ['#details', '#map', '#recs', '#accommodations', '#rsvp'].forEach(function(id) {
         var el = document.querySelector(id);
         if (el) el.style.display = 'none';
     });
 
-    ['#details', '#map', '#recs', '#accommodations', '#registry', '#rsvp'].forEach(function(href) {
+    ['#details', '#map', '#recs', '#accommodations', '#rsvp'].forEach(function(href) {
         var link = document.querySelector('.nav-menu a[href="' + href + '"]');
         if (link) link.parentElement.style.display = 'none';
     });


### PR DESCRIPTION
## Summary

- The `applyPostWeddingState()` function was hiding the `#registry` section once the wedding date passed (2026-06-20)
- Removed `#registry` from the list of sections/nav links that get hidden post-wedding
- The Gift Registry is now visible to guests who want to contribute after the wedding

## What changed

In `js/script.js`, the two arrays inside `applyPostWeddingState()` previously included `'#registry'`. Removing it from both arrays (section hide + nav link hide) restores the registry section's visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVWj9dpagSB6wqKah7t9eK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVWj9dpagSB6wqKah7t9eK)_