### PR TITLE
Show registry section after wedding date

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
         href="data:image/svg+xml,&lt;svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'&gt;&lt;text y='.9em' font-size='90'&gt;❤️&lt;/text&gt;&lt;/svg&gt;">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="css/style.css?v=c2871365">
+    <link rel="stylesheet" href="css/style.css?v=5c247d62">
     <!-- Load fonts async so they don't block first paint -->
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lora:wght@400;500;600&family=Montserrat:wght@300;400;500;600&family=Poppins:wght@300;400;500;600&family=Playfair+Display:wght@400;500;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lora:wght@400;500;600&family=Montserrat:wght@300;400;500;600&family=Poppins:wght@300;400;500;600&family=Playfair+Display:wght@400;500;600&display=swap"></noscript>
@@ -1174,7 +1174,7 @@
     </footer>
 </div>
 
-<script src="js/script.js?v=c2871365"></script>
+<script src="js/script.js?v=5c247d62"></script>
 
 <!-- Reveal the "Share Your Photos" link only on/after the wedding day.
      Add ?showupload=1 to the URL to preview it before then. -->

--- a/upload/index.html
+++ b/upload/index.html
@@ -10,7 +10,7 @@
         href="data:image/svg+xml,&lt;svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'&gt;&lt;text y='.9em' font-size='90'&gt;❤️&lt;/text&gt;&lt;/svg&gt;">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="../css/style.css?v=c2871365">
+    <link rel="stylesheet" href="../css/style.css?v=5c247d62">
     <link rel="preload" as="style"
         href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Lora:wght@400;500;600&family=Montserrat:wght@300;400;500;600&family=Poppins:wght@300;400;500;600&family=Playfair+Display:wght@400;500;600&display=swap"
         onload="this.onload=null;this.rel='stylesheet'">


### PR DESCRIPTION
## Summary

- Removed `#registry` from the post-wedding hidden sections in `applyPostWeddingState()` so the Gift Registry stays visible after the wedding date
- Bumped asset version (`?v=5c247d62`) in `index.html` and `upload/index.html` to bust the browser cache and ensure the updated script is loaded

## Changes

- `js/script.js` — removed `#registry` from the two arrays that hide sections/nav links post-wedding
- `index.html` + `upload/index.html` — updated cache-busting version query param

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVWj9dpagSB6wqKah7t9eK

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVWj9dpagSB6wqKah7t9eK)_